### PR TITLE
build: add automatic PyInstaller bootloader build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,6 +11,25 @@ rm -rf build/ dist/ 2>/dev/null || true
 # Create build directory
 mkdir -p build
 
+# Build PyInstaller bootloader if not present
+PYINSTALLER_PATH=$(dirname $(python3 -c "import PyInstaller; print(PyInstaller.__file__)"))
+BOOTLOADER_DIR="$PYINSTALLER_PATH/bootloader/Linux-64bit-intel"
+BOOTLOADER_PATH="$BOOTLOADER_DIR/run"
+if [ ! -f "$BOOTLOADER_PATH" ]; then
+  echo "PyInstaller bootloader not found. Building it..."
+  TEMP_DIR="/tmp/pyinstaller_build"
+  rm -rf "$TEMP_DIR"
+  git clone https://github.com/pyinstaller/pyinstaller.git "$TEMP_DIR"
+  cd "$TEMP_DIR"/bootloader
+  python3 ./waf distclean all --target-arch=64bit
+  cd -
+  mkdir -p "$BOOTLOADER_DIR"
+  cp "$TEMP_DIR/bootloader/build/release/run" "$BOOTLOADER_DIR/"
+  cp "$TEMP_DIR/bootloader/build/debug/run_d" "$BOOTLOADER_DIR/"
+  rm -rf "$TEMP_DIR"
+  echo "Bootloader built and copied to $BOOTLOADER_DIR"
+fi
+
 # Build the executable
 echo "Running PyInstaller..."
 pyinstaller --onefile --name gangwar --add-data "src/templates:templates" --add-data "src/static:static" --add-data "model:model" --windowed src/main.py


### PR DESCRIPTION
Add a check in build.sh to verify if the PyInstaller bootloader exists. If missing, clone the PyInstaller repo, build the 64-bit Linux bootloader, copy it to the appropriate directory, and clean up temporary files. This ensures reliable builds in environments without a pre-built bootloader.