### PR TITLE
feat: add special visit feature in crackhouse

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -488,6 +488,7 @@ class GameState:
     weapons: Weapons = field(default_factory=Weapons)
     drugs: Drugs = field(default_factory=Drugs)
     gang_members: List[GangMember] = field(default_factory=list)
+    last_prostitute_benefit_day: int = 0
 
     @property
     def max_health(self) -> int:

--- a/src/templates/crackhouse.html
+++ b/src/templates/crackhouse.html
@@ -97,6 +97,7 @@
     
     <div class="actions">
         <a href="{{ url_for('city') }}" class="btn btn-primary">Back to City</a>
+        <a href="{{ url_for('visit_prostitutes') }}" class="btn btn-danger">Visit Prostitutes</a>
     </div>
 
 


### PR DESCRIPTION
Introduce a new game mechanic allowing players to visit prostitutes for potential benefits. Add `last_prostitute_benefit_day` field to GameState for tracking the last benefit day, preventing abuse. Include a new "Visit Prostitutes" button in crackhouse.html to access this feature, enhancing gameplay options in the gangwar game.